### PR TITLE
Fix cached_property not overriding correctly

### DIFF
--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -91,7 +91,7 @@ class cached_property(property, t.Generic[_T]):
                 res = {}
                 setattr(obj, self.slot_name, res)
             return res
-        
+
     def __set__(self, obj: object, value: _T) -> None:
         self._get_cache(obj)[self] = value
 


### PR DESCRIPTION
Currently overriding a cached property causes to surprising behavior (see below). I propose a fix for this issue.

```py3
from werkzeug.utils import cached_property


class Parent:
    @cached_property
    def foo(self):
        return 1


class Child(Parent):
    @cached_property
    def foo(self):
        return 20 + super().foo

    def bar(self):
        return 300 + super().foo


a = Child()
a.foo
assert a.bar() == 321  # BUG: should be 301

b = Child()
b.bar()
assert b.foo == 1  # BUG: should be 21
```

TODO:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
